### PR TITLE
fixed typo  in WSTest.cpp

### DIFF
--- a/client/test/WSTest.cpp
+++ b/client/test/WSTest.cpp
@@ -3,6 +3,6 @@
 
 void WSTest::onRun() {
 
-  OATPP_LOGD(TAG, "TODO - write tests");
+  OATPP_LOGd(TAG, "TODO - write tests");
 
 }


### PR DESCRIPTION
There's a typo in the logging macro - D instead of d